### PR TITLE
Changed displayName to "Nord"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mailspring-nord-theme",
   "title": "a dark bluish theme",
-  "displayName": "Mailspring Nordic Theme",
+  "displayName": "Nord",
   "theme": "ui",
   "version": "1.0.0",
   "description": "A Nordic Theme for Mailspring!",


### PR DESCRIPTION
The old displayName gets cut off in the Theme Changer:
![before](https://user-images.githubusercontent.com/29703429/103842333-cce39100-50e9-11eb-9a9c-b52540d9253c.png)
*Might depend on scaling preferences (in Settings > Appearance > Scaling)*

The new displayName doesn't get cut off and is more like the simpler naming convention of other themes:
![after](https://user-images.githubusercontent.com/29703429/103842466-1b912b00-50ea-11eb-821a-b28eff64276d.png)